### PR TITLE
Colored keys support

### DIFF
--- a/input/drivers/sdl_input.c
+++ b/input/drivers/sdl_input.c
@@ -99,6 +99,14 @@ static bool sdl_key_pressed(int key)
    }
    if (key == RETROK_ESCAPE && keymap[SDL_WEBOS_SCANCODE_EXIT])
       return true;
+   if (key == RETROK_x && keymap[SDL_WEBOS_SCANCODE_RED])
+      return true;
+   if (key == RETROK_z && keymap[SDL_WEBOS_SCANCODE_GREEN])
+      return true;
+   if (key == RETROK_s && keymap[SDL_WEBOS_SCANCODE_YELLOW])
+      return true;
+   if (key == RETROK_a && keymap[SDL_WEBOS_SCANCODE_BLUE])
+      return true;
 #endif
 
    if (sym >= (unsigned)num_keys)
@@ -384,6 +392,18 @@ static void sdl_input_poll(void *data)
             // Because webOS is sending DOWN/UP at the same time, we save this flag for later
             sdl_webos_special_keymap[sdl_webos_spkey_back] |= event.type == SDL_KEYDOWN;
             code = RETROK_BACKSPACE;
+            break;
+         case SDL_WEBOS_SCANCODE_RED:
+            code = RETROK_x;
+            break;
+         case SDL_WEBOS_SCANCODE_GREEN:
+            code = RETROK_z;
+            break;
+         case SDL_WEBOS_SCANCODE_YELLOW:
+            code = RETROK_s;
+            break;
+         case SDL_WEBOS_SCANCODE_BLUE:
+            code = RETROK_a;
             break;
          case SDL_WEBOS_SCANCODE_EXIT:
             code = RETROK_ESCAPE;

--- a/input/drivers/sdl_input.c
+++ b/input/drivers/sdl_input.c
@@ -411,6 +411,14 @@ static void sdl_input_poll(void *data)
          default:
             break;
          }
+
+         // Disable cursor when using the buttons
+         if (code != RETROK_RETURN
+                 && event.key.keysym.scancode != SDL_WEBOS_SCANCODE_CURSOR_HIDE
+                 && event.key.keysym.scancode != SDL_WEBOS_SCANCODE_CURSOR_SHOW) {
+            SDL_ShowCursor(SDL_DISABLE);
+            SDL_ShowCursor(SDL_ENABLE);
+         }
 #endif
 
          if (event.key.keysym.mod & KMOD_SHIFT)

--- a/webos/Makefile
+++ b/webos/Makefile
@@ -3,20 +3,20 @@ all: package
 RETROARCH_PREFIX = ${PWD}/prefix
 
 configure:
-	cd ../; \
+	cd ../
 	./configure --build=x86_64-linux-gnu --host=arm-webos-linux-gnueabi --prefix=$(RETROARCH_PREFIX) --enable-opengles \
-		--enable-egl --disable-udev --disable-videocore --disable-ffmpeg --disable-kms --enable-neon --enable-sdl2 ;\
+		--enable-egl --disable-udev --disable-videocore --disable-ffmpeg --disable-kms --enable-neon --enable-sdl2
 
 retroarch:
-	cd ../; \
+	cd ../
 	make HAVE_WEBOS=1 -j$(nproc) install
 
 package: retroarch
-	rm -rf dist *.ipk; \
-	mkdir -p dist/lib; \
-	cp -vf -t dist/lib /opt/webos-sdk-x86_64/1.0.g/sysroots/armv7a-neon-webos-linux-gnueabi/usr/lib/libstdc++.so.6; \
-	cp -vf -t dist/ appinfo.json icon160.png prefix/bin/retroarch; \
-	arm-webos-linux-gnueabi-strip dist/retroarch; \
+	rm -rf dist *.ipk
+	mkdir -p dist/lib
+	cp -vf -t dist/lib /opt/webos-sdk-x86_64/1.0.g/sysroots/armv7a-neon-webos-linux-gnueabi/usr/lib/libstdc++.so.6
+	cp -vf -t dist/ appinfo.json icon160.png prefix/bin/retroarch
+	arm-webos-linux-gnueabi-strip dist/retroarch
 	ares-package dist
 
 install: package
@@ -26,7 +26,7 @@ launch: install
 	ares-launch com.retroarch
 
 clean:
-	rm -rf dist; \
-	rm -rf prefix; \
-	cd ..; \
+	rm -rf dist
+	rm -rf prefix
+	cd ..
 	make clean


### PR DESCRIPTION
This adds support for colored keys:
* red = `x` key = `B` ("right" action)
* green = `z` key = `A` ("down" action)
* yellow = `s` key = `Y` ("up" action)
* blue = `a` key = `X` ("left" action)

Also now cursor should get automatically disabled when using remote keys (except for ok button which is used as a "mouse click")