### PR TITLE
Update appinfo.json: AppId with proper structure

### DIFF
--- a/webos/appinfo.json
+++ b/webos/appinfo.json
@@ -1,5 +1,5 @@
 {
-    "id": "com.retroarch",
+    "id": "com.webosbrew.retroarch",
     "version": "1.9.1",
     "vendor": "webosbrew.org",
     "title": "RetroArch",


### PR DESCRIPTION
## Description

In order to reuse these apps in non-TV environment (webOS OSE, LuneOS) it would require to have a properly formatted appId for AppInstallD to be happy.

This should work on TV's too, however not tested at my end.

## Related Issues

RetroArch doesn't install on LuneOS and webOS OSE.

[code]
Nov 08 13:02:51 qemux86-64 WebAppMgr[548]: [] [pmlog] WAM PALMSYSTEM {"APP_ID":"org.webosports.app.preware","INSTANCE_ID":"58b9fd39-5ea0-4f06-af1d-bc7370f3eb530","PID":1062} webOSSystem.launchParams Updated by app; {"displayAffinity":0,"instanceId":"58b9fd39-5ea0-4f06-af1d-bc7370f3eb530","palm-command":"open-app-menu"}
Nov 08 13:02:51 qemux86-64 WebAppMgr[548]: [] [pmlog] WAM PALMSYSTEM {"APP_ID":"org.webosports.app.preware","INSTANCE_ID":"58b9fd39-5ea0-4f06-af1d-bc7370f3eb530","PID":1062} Update; key:launchParams; value:{"displayAffinity":0,"instanceId":"58b9fd39-5ea0-4f06-af1d-bc7370f3eb530","palm-command":"open-app-menu"}
Nov 08 13:02:51 qemux86-64 webapp-mgr.sh[548]: [548:548:1108/130251.525956:INFO:CONSOLE(285)] org.webosports.app.preware "<strong>Downloading Feed Information</strong><br>Hominid-Software<br><br>HTTP/1.1 200 OK", source: file://org.webosports.app.preware-webos/usr/palm/applications/org.webosports.app.preware/build/app.js (285)
Nov 08 13:02:51 qemux86-64 org.webosports.service.ipkg[504]: Running command /usr/bin/curl --user-agent Preware -H "Device-Id: webOS" -H "Auth-Token: konami" --create-dirs --location --fail --show-error --output /media/cryptofs/apps/var/lib/opkg/cache/Hominid-Software https://hominidsoftware.com/preware/Packages 2>&1
Nov 08 13:02:52 qemux86-64 webapp-mgr.sh[548]: [548:548:1108/130252.045827:INFO:CONSOLE(285)] org.webosports.app.preware "<strong>Downloading Feed Information</strong><br>Hominid-Software<br><br>Transferred: 5166 / 5166<br>Time Left: --:--:--<br>Transfer Speed: 10564", source: file://org.webosports.app.preware-webos/usr/palm/applications/org.webosports.app.preware/build/app.js (285)
Nov 08 13:02:52 qemux86-64 webapp-mgr.sh[548]: [548:548:1108/130252.048958:INFO:CONSOLE(285)] org.webosports.app.preware "<strong>Downloading Feed Information</strong><br>Macaw-enyo", source: file://org.webosports.app.preware-webos/usr/palm/applications/org.webosports.app.preware/build/app.js (285)
Nov 08 13:02:52 qemux86-64 org.webosports.service.ipkg[504]: Running command /usr/bin/curl -s -I --user-agent Preware -H "Device-Id: webOS" -H "Auth-Token: konami" --location --fail --show-error https://minego.net/preware/macaw-enyo/Packages 2>&1
Nov 08 13:03:03 qemux86-64 webapp-mgr.sh[548]: [548:548:1108/130303.039514:INFO:CONSOLE(300)] org.webosports.app.preware "PackageId: com.retroarch", source: file://org.webosports.app.preware-webos/usr/palm/applications/org.webosports.app.preware/build/app.js (300)
Nov 08 13:03:03 qemux86-64 org.webosports.service.ipkg[504]: Running command /usr/bin/curl -s -I --user-agent Preware --location --fail --show-error file:///media/internal/com.retroarch_1.9.1_arm.ipk 2>&1
Nov 08 13:03:03 qemux86-64 org.webosports.service.ipkg[504]: Running command /usr/bin/curl --user-agent Preware --create-dirs --location --fail --show-error --output /media/internal/.developer/com.retroarch_1.9.1_arm.ipk file:///media/internal/com.retroarch_1.9.1_arm.ipk 2>&1
Nov 08 13:03:03 qemux86-64 org.webosports.service.ipkg[504]: Running command /usr/bin/ar p /media/internal/.developer/com.retroarch_1.9.1_arm.ipk control.tar.gz | /bin/tar -O -z -x --no-anchored -f - control | /bin/sed -n -e 's/^Package: //p' 2>&1
Nov 08 13:03:03 qemux86-64 org.webosports.service.ipkg[504]: Running command /usr/bin/luna-send -n 6 luna://com.webos.appInstallService/install '{"subscribe":true, "id": "com.retroarch", "ipkUrl": "/media/internal/.developer/com.retroarch_1.9.1_arm.ipk"}' 2>&1
Nov 08 13:03:03 qemux86-64 appinstalld[396]: [] [pmlog] AppInstallD APP_INSTALL_REQ {"app_id":"com.retroarch","caller":"com.webos.lunasend-1126"}
Nov 08 13:03:03 qemux86-64 sam[552]: [I][AppInstallService][onStatus][SubscriptionResponse] com.webos.appInstallService
Nov 08 13:03:03 qemux86-64 appinstalld[396]: [] [pmlog] AppInstallD PACKAGE_INFO {"app_id":"com.retroarch","package":"com.retroarch","version":"1.9.1"}
Nov 08 13:03:03 qemux86-64 sam[552]: [I][AppInstallService][onStatus][SubscriptionResponse] com.webos.appInstallService
Nov 08 13:03:03 qemux86-64 sam[552]: [I][AppInstallService][onStatus][SubscriptionResponse] com.webos.appInstallService
Nov 08 13:03:03 qemux86-64 sam[552]: [I][AppInstallService][onStatus][SubscriptionResponse] com.webos.appInstallService
Nov 08 13:03:03 qemux86-64 sam[552]: [I][ApplicationManager][onAPICalled][APIRequest] API(/getAppInfo) Sender(com.webos.appInstallService)
Nov 08 13:03:03 qemux86-64 sam[552]: [W][LunaTask][setErrCodeAndText] errorCode(2) errorText(Invalid appId specified OR Unsupported Application Type: com.retroarch)
Nov 08 13:03:03 qemux86-64 sam[552]: [I][AppInstallService][onStatus][SubscriptionResponse] com.webos.appInstallService
Nov 08 13:03:03 qemux86-64 sam[552]: [I][AppInstallService][onStatus][SubscriptionResponse] com.webos.appInstallService
Nov 08 13:03:03 qemux86-64 sam[552]: [I][AppInstallService][onStatus][SubscriptionResponse] com.webos.appInstallService
Nov 08 13:03:03 qemux86-64 sam[552]: [I][ApplicationManager][onAPICalled][APIRequest] API(/getAppInfo) Sender(com.webos.appInstallService)
Nov 08 13:03:03 qemux86-64 sam[552]: [W][LunaTask][setErrCodeAndText] errorCode(2) errorText(Invalid appId specified OR Unsupported Application Type: com.retroarch)
Nov 08 13:03:03 qemux86-64 appinstalld[396]: [] [pmlog] <default-lib> LS_SOCK {"ERROR_CODE":32,"ERROR":"Broken pipe","APP_ID":"com.webos.lunasend-1126","UNIQUE_NAME":"masZuwDN"} Error when attempting to send to fd: 11
Nov 08 13:03:03 qemux86-64 sam[552]: [I][ApplicationManager][onAPICalled][APIRequest] API(/running) Sender(com.webos.appInstallService)
Nov 08 13:03:03 qemux86-64 sam[552]: [I][AppInstallService][onStatus][SubscriptionResponse] com.webos.appInstallService
Nov 08 13:03:03 qemux86-64 sam[552]: [I][AppInstallService][onStatus][SubscriptionResponse] com.webos.appInstallService
Nov 08 13:03:03 qemux86-64 sam[552]: [I][AppInstallService][onStatus][SubscriptionResponse] com.webos.appInstallService
Nov 08 13:03:03 qemux86-64 LunaAppManager[639]: QWarning: QFSFileEngine::open: No file name specified
Nov 08 13:03:03 qemux86-64 LunaAppManager[639]: QWarning: QFSFileEngine::open: No file name specified
Nov 08 13:03:03 qemux86-64 ApplicationInstallerUtility[1131]: ApplicationInstallerUtility configured to not use cryptofs
Nov 08 13:03:03 qemux86-64 ApplicationInstallerUtility[1131]: Install type is not passed, set to default internal.
Nov 08 13:03:03 qemux86-64 ApplicationInstallerUtility[1131]: Install called with args: target: /media/internal/.developer/com.retroarch_1.9.1_arm.ipk, verify: false, uncompressed app size (in KB): 0
Nov 08 13:03:03 qemux86-64 sam[552]: [I][AppInstallService][onStatus][SubscriptionResponse] com.webos.appInstallService
Nov 08 13:03:03 qemux86-64 ApplicationInstallerUtility[1131]: Step 3: executing: opkg -o /media/cryptofs/apps --add-arch all:1 --add-arch any:6 --add-arch noarch:11 --add-arch x86_64:16 --add-arch core2-64:21 --add-arch qemux86_64:26 install /media/internal/.developer/com.retroarch_1.9.1_arm.ipk -f /etc/palm/appinstalld/opkg.conf
Nov 08 13:03:03 qemux86-64 ApplicationInstallerUtility[1131]: Step 3: ipkg resultStatus = 1 , exit status = 255
Nov 08 13:03:03 qemux86-64 ApplicationInstallerUtility[1131]: Non zero exit code from opkg install
Nov 08 13:03:03 qemux86-64 appinstalld[396]: [] [pmlog] AppInstallD TASK_ERROR {"app_id":"com.retroarch","error_code":-5,"error_text":"FAILED_IPKG_INSTALL"}
Nov 08 13:03:03 qemux86-64 sam[552]: [I][AppInstallService][onStatus][SubscriptionResponse] com.webos.appInstallService
Nov 08 13:03:03 qemux86-64 sam[552]: [W][AppDescriptionList][scanApp][com.retroarch] /media/developer/apps/usr/palm/applications/com.retroarch is not exist
Nov 08 13:03:03 qemux86-64 sam[552]: [W][AppDescriptionList][scanApp][com.retroarch] /media/cryptofs/apps/usr/palm/applications/com.retroarch is not exist
Nov 08 13:03:03 qemux86-64 sam[552]: [W][AppDescriptionList][scanApp][com.retroarch] /media/system/apps/usr/palm/applications/com.retroarch is not exist
Nov 08 13:03:03 qemux86-64 sam[552]: [W][AppDescriptionList][scanApp][com.retroarch] /usr/palm/applications/com.retroarch is not exist
Nov 08 13:03:03 qemux86-64 sam[552]: [W][AppDescriptionList][scanApp][com.retroarch] /mnt/otncabi/usr/palm/applications/com.retroarch is not exist
Nov 08 13:03:03 qemux86-64 sam[552]: [W][AppDescriptionList][scanApp][com.retroarch] /mnt/otycabi/usr/palm/applications/com.retroarch is not exist
Nov 08 13:03:03 qemux86-64 sam[552]: [W][AppDescriptionList][scanApp][com.retroarch] Failed to scan AppDescription
Nov 08 13:03:03 qemux86-64 LunaAppManager[639]: QWarning: QFSFileEngine::open: No file name specified
Nov 08 13:03:03 qemux86-64 appinstalld[396]: [] [pmlog] AppInstallD IPK_INSTALL_FAIL {"app_id":"com.retroarch","status":2304}
Nov 08 13:03:03 qemux86-64 appinstalld[396]: [] [pmlog] AppInstallD STATUS_UNDEF {"app_id":"com.retroarch","status":24}
Nov 08 13:03:03 qemux86-64 appinstalld[396]: [] [pmlog] AppInstallD APP_REMOVE_REQ {"app_id":"com.retroarch","caller":"com.webos.appInstallService"}
[/code]