### PR TITLE
webOS: replace ncpu (go), fix undefined function compile error, use p…

### DIFF
--- a/Makefile.webos
+++ b/Makefile.webos
@@ -140,10 +140,12 @@ DEFINES += -DHAVE_PULSE
 DEFINES += -DHAVE_NETWORKING -DHAVE_IFINFO -DHAVE_ONLINE_UPDATER -DHAVE_UPDATE_ASSETS -DHAVE_UPDATE_CORES
 DEFINES += -DHAVE_UPDATE_CORE_INFO
 
-SDL2_CFLAGS := $(shell pkg-config --cflags sdl2)
-SDL2_LIBS := $(shell pkg-config --libs sdl2)
+PKG_CONFIG=$(SDKTARGETSYSROOT)/../../bin/pkg-config
+
+SDL2_CFLAGS := $(shell $(PKG_CONFIG) --cflags sdl2)
+SDL2_LIBS := $(shell $(PKG_CONFIG) --libs sdl2)
 OPENGLES_LIBS = -lGLESv2
-PULSE_LIBS = $(shell pkg-config --libs libpulse)
+PULSE_LIBS = $(shell $(PKG_CONFIG) --libs libpulse)
 MMAP_LIBS = -lc
 NEON_CFLAGS = -mfpu=neon
 NEON_ASFLAGS = -mfpu=neon

--- a/config.def.h
+++ b/config.def.h
@@ -1684,6 +1684,8 @@
 
 #if defined(HAKCHI)
 #define DEFAULT_BUILDBOT_SERVER_URL "http://hakchicloud.com/Libretro_Cores/"
+#elif defined(WEBOS)
+#define DEFAULT_BUILDBOT_SERVER_URL "https://csdougliss.github.io/webos-retroarch-cores/armv7a/"
 #elif defined(ANDROID)
 #if defined(ANDROID_ARM_V7)
 #define DEFAULT_BUILDBOT_SERVER_URL "http://buildbot.libretro.com/nightly/android/latest/armeabi-v7a/"

--- a/retroarch.c
+++ b/retroarch.c
@@ -8208,7 +8208,7 @@ bool retroarch_main_quit(void)
    retroarch_menu_running_finished(true);
 #endif
 
-#ifdef HAVE_ACCESSIBILITY
+#ifdef HAVE_TRANSLATE
    translation_release(false);
 #ifdef HAVE_THREADS
    if (access_st->image_lock)

--- a/webos/README.md
+++ b/webos/README.md
@@ -1,7 +1,7 @@
 ## Building
 ```sh
 make -f Makefile.webos clean
-make -f Makefile.webos -j$(ncpu --all) ipk
+make -f Makefile.webos -j$(getconf _NPROCESSORS_ONLN) ipk
 ```
 
 ## Testing

--- a/webos/appinfo.json
+++ b/webos/appinfo.json
@@ -1,6 +1,6 @@
 {
-    "id": "com.retroarch",
-    "version": "1.9.8",
+    "id": "com.webosbrew.retroarch",
+    "version": "1.17.0",
     "vendor": "libretro.com",
     "title": "RetroArch",
     "icon": "icon160.png",


### PR DESCRIPTION
Updates relevant to make 1.17 compile correctly.

The URL used for buildbot will be replaced when the webosbrew URL is setup